### PR TITLE
iam role "cloudquery-ro" is exist

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -22,7 +22,7 @@ Resources:
   CloudqueryReadOnly:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: cloudquery-ro
+      RoleName: cloudquery-mgmt-ro
       Description: Admin Role that CloudQuery will use to fetch resources from member accounts
       Policies:
         - PolicyName: root


### PR DESCRIPTION
when deploy the CNF template, in delegrated admin account, I got error that iam role "cloudquery-ro" is exist on delegrated account only. No issue to other stack accounts. 

Raise PR to fix this issue

Reason why we have no problem if this template is deployed in Organization Management (Admin) Account, because it will not add management account as its stack acount. 

